### PR TITLE
Logical logging: Action Trait changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## 28th Mar 2024
+
+### ft-sdk `0.1.2`
+
+- Added: added action() wrapper for _action() in Action trait (for logging)
+
 ## 22nd Mar 2024
 
 ### ft-sdk `0.1.1`

--- a/ft-sdk/Cargo.toml
+++ b/ft-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ft-sdk"
-version = "0.1.1"
+version = "0.1.2"
 description = "ft-sdk: SDK for building FifthTry Applications"
 authors.workspace = true
 edition.workspace = true

--- a/ft-sdk/src/in_.rs
+++ b/ft-sdk/src/in_.rs
@@ -22,4 +22,12 @@ impl In {
             .get(http::header::USER_AGENT)
             .and_then(|v| v.to_str().map(|v| v.to_string()).ok()).unwrap_or("anonymous".to_string())
     }
+
+    pub fn json_body<T: serde::de::DeserializeOwned>(&self) -> serde_json::Result<T> {
+        serde_json::from_slice(&self.req.body())
+    }
+
+    pub fn query_string(&self) -> String {
+        self.req.uri().query().unwrap_or_default().to_string()
+    }
 }

--- a/ft-sdk/src/in_.rs
+++ b/ft-sdk/src/in_.rs
@@ -1,5 +1,3 @@
-use serde_json::Value;
-
 pub struct In {
     pub ud: Option<ft_sdk::UserData>,
     pub req: http::Request<bytes::Bytes>,
@@ -35,7 +33,7 @@ impl In {
         // Removing password fields from body (for logging)
         let json_body = serde_json::from_slice(&self.req.body())?;
         let value = match json_body {
-            Value::Object(mut v) => {
+            serde_json::Value::Object(mut v) => {
                 v.retain(|key, _| !key.contains("password"));
                 serde_json::Value::Object(v)
             }

--- a/ft-sdk/src/in_.rs
+++ b/ft-sdk/src/in_.rs
@@ -16,4 +16,10 @@ impl In {
             form_errors: std::collections::HashMap::new(),
         })
     }
+
+    pub fn user_agent(&self) -> String {
+        self.req.headers()
+            .get(http::header::USER_AGENT)
+            .and_then(|v| v.to_str().map(|v| v.to_string()).ok()).unwrap_or("anonymous".to_string())
+    }
 }

--- a/ft-sdk/src/layout.rs
+++ b/ft-sdk/src/layout.rs
@@ -122,7 +122,7 @@ pub trait Layout {
             A: ActionWithLog<Self, Self::Error>,
             Self: Sized,
     {
-        let start_time = std::time::Instant::now();
+        let start_time = ft_sys::now();
         let in_ = ft_sdk::In::from_request(r)?;
         let mut l = Self::from_in(in_, RequestType::Action)?;
         let a = A::validate(&mut l)?;
@@ -134,7 +134,7 @@ pub trait Layout {
 
     fn json(&mut self, o: serde_json::Value) -> Result<serde_json::Value, Self::Error>;
     fn render_error(e: Self::Error) -> http::Response<bytes::Bytes>;
-    fn log_to_event(&mut self, start_time: std::time::Instant) -> Result<(), Self::Error>;
+    fn log_to_event(&mut self, start_time: chrono::DateTime<chrono::Utc>) -> Result<(),Self::Error>;
 }
 
 fn a2r(r: ActionOutput) -> http::Response<bytes::Bytes> {

--- a/ft-sdk/src/lib.rs
+++ b/ft-sdk/src/lib.rs
@@ -19,7 +19,7 @@ pub use ft_sys::{env, println, PgConnection};
 pub use ft_sys::{http, UserData};
 pub use in_::In;
 pub use json_body::{JsonBody, JsonBodyExt};
-pub use layout::{Action, ActionOutput, Layout, Page, RequestType};
+pub use layout::{Action, ActionWithLog, ActionOutput, Layout, Page, RequestType};
 pub use query::{Query, QueryExt};
 
 /// Get a connection to the default postgres database.

--- a/ft-sdk/src/lib.rs
+++ b/ft-sdk/src/lib.rs
@@ -19,7 +19,7 @@ pub use ft_sys::{env, println, PgConnection};
 pub use ft_sys::{http, UserData};
 pub use in_::In;
 pub use json_body::{JsonBody, JsonBodyExt};
-pub use layout::{Action, Action2, ActionOutput, Layout, Page, RequestType};
+pub use layout::{Action, ActionOutput, Layout, Page, RequestType};
 pub use query::{Query, QueryExt};
 
 /// Get a connection to the default postgres database.

--- a/ft-sdk/src/lib.rs
+++ b/ft-sdk/src/lib.rs
@@ -19,7 +19,7 @@ pub use ft_sys::{env, println, PgConnection};
 pub use ft_sys::{http, UserData};
 pub use in_::In;
 pub use json_body::{JsonBody, JsonBodyExt};
-pub use layout::{Action, ActionWithLog, ActionOutput, Layout, Page, RequestType};
+pub use layout::{Action, Action2, ActionOutput, Layout, Page, RequestType};
 pub use query::{Query, QueryExt};
 
 /// Get a connection to the default postgres database.


### PR DESCRIPTION
Action2 trait supports logging which will be replaced with the existing Action trait later
Action2 trait is made to test logging before using it on all existing actions to avoid breaking existing action routes.