### PR TITLE
feat: ft_sdk::email::queue_email()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "ft-sys-shared"
-version = "0.1.1"
+version = "0.1.1-alpha.1"
 dependencies = [
  "bytes",
  "http",

--- a/ft-sdk/src/email.rs
+++ b/ft-sdk/src/email.rs
@@ -1,0 +1,66 @@
+#[derive(Debug, thiserror::Error)]
+pub enum MailError {
+    #[error("error enqueueing email: {0}")]
+    EnqueueError(String),
+}
+
+/// add a email sending request to the queue
+/// requests get picked up by the email worker
+///
+/// # Arguments
+/// * `to` - (name, email)
+/// * `subject` - email subject
+/// * `body` - email body
+/// * `mkind` - mail kind, used for logical logging purposes
+pub async fn queue_email(
+    to: (&str, &str),
+    subject: &str,
+    conn: &mut ft_sdk::Connection,
+    // TODO: add support for text emails
+    html_body: &str,
+    mkind: &str,
+) -> Result<(), MailError> {
+    use diesel::prelude::*;
+
+    let now = chrono::Utc::now();
+    let (name, email) = to;
+
+    let affected = diesel::insert_into(fastn_email_queue::table)
+        .values((
+            fastn_email_queue::to_email.eq(email),
+            fastn_email_queue::to_name.eq(name),
+            fastn_email_queue::subject.eq(subject),
+            fastn_email_queue::body.eq(html_body),
+            fastn_email_queue::retry_count.eq(0),
+            fastn_email_queue::created_at.eq(now),
+            fastn_email_queue::updated_at.eq(now),
+            fastn_email_queue::mkind.eq(mkind),
+            fastn_email_queue::status.eq("PENDING"),
+        ))
+        .execute(conn)
+        .map_err(|e| MailError::EnqueueError(e.to_string()))?;
+
+    ft_sdk::println!(
+        "email_queue_request_sucess: {} request registered",
+        affected
+    );
+
+    Ok(())
+}
+
+diesel::table! {
+    fastn_email_queue (id) {
+        id -> Int8,
+        to_email -> Text,
+        to_name -> Text,
+        subject -> Text,
+        body -> Text,
+        // used by email worker
+        retry_count -> Integer,
+        created_at -> Timestamptz,
+        updated_at -> Timestamptz,
+        // for logical logging
+        mkind -> Text,
+        status -> Text,
+    }
+}

--- a/ft-sdk/src/lib.rs
+++ b/ft-sdk/src/lib.rs
@@ -9,6 +9,7 @@ extern crate self as ft_sdk;
 mod auth;
 mod cookie;
 mod crypto;
+pub mod email;
 mod in_;
 mod json_body;
 mod layout;

--- a/ft-sys/Cargo.toml
+++ b/ft-sys/Cargo.toml
@@ -20,7 +20,7 @@ serde.workspace = true
 serde_json.workspace = true
 http.workspace = true
 bytes.workspace = true
-ft-sys-shared = { path = "../ft-sys-shared", version = "0.1.1" }
+ft-sys-shared = { path = "../ft-sys-shared", version = "0.1.1-alpha.1" }
 chrono.workspace = true
 serde_sqlite_jsonb = { workspace = true, optional = true }
 


### PR DESCRIPTION
A db agnostic implementation that replaces `fastn_ds::send_email` of
fastn.

Instead of sending actual emails, this queues them in a database table.
An email worker will consume this queue and handle actual sending of
email.

As of writing this commit no email worker implementation exists in
fastn.
