### PR TITLE
fix/auth prov

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "thiserror",
+ "uuid",
 ]
 
 [[package]]
@@ -504,6 +505,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "uuid"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ diesel = { version = "2", features = ["serde_json"] }
 serde_urlencoded = "0.7"
 include_dir = "0.7"
 rand_core = "0.6"
+uuid = { version = "1.8", default-features = false, features = ["v8"] }
 
 [workspace.dependencies.rusqlite]
 version = "0.31"

--- a/ft-sdk/Cargo.toml
+++ b/ft-sdk/Cargo.toml
@@ -15,7 +15,7 @@ postgres = ["ft-sys/postgres", "diesel"]
 sqlite-default = ["ft-sys/sqlite-default", "sqlite"]
 sqlite = ["ft-sys/sqlite", "diesel"]
 migration = [] # only if either sqlite-default or postgres-default is activated
-auth-provider = []
+auth-provider = ["uuid"]
 
 [dependencies]
 ft-sys = { path = "../ft-sys", version = "0.1.2", default-features = false }
@@ -29,6 +29,7 @@ serde_urlencoded.workspace = true
 diesel = { workspace = true, optional = true }
 include_dir.workspace = true
 rand_core.workspace = true
+uuid = { workspace = true, optional = true }
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/ft-sdk/Cargo.toml
+++ b/ft-sdk/Cargo.toml
@@ -15,7 +15,7 @@ postgres = ["ft-sys/postgres", "diesel"]
 sqlite-default = ["ft-sys/sqlite-default", "sqlite"]
 sqlite = ["ft-sys/sqlite", "diesel"]
 migration = [] # only if either sqlite-default or postgres-default is activated
-auth-providers = []
+auth-provider = []
 
 [dependencies]
 ft-sys = { path = "../ft-sys", version = "0.1.2", default-features = false }

--- a/ft-sdk/src/auth/db.rs
+++ b/ft-sdk/src/auth/db.rs
@@ -15,7 +15,7 @@ diesel::table! {
     use diesel::sql_types::*;
 
     fastn_session (id) {
-        id -> Int8,
+        id -> Text,
         uid -> Nullable<Int8>,
         data -> Jsonb,
         updated_at -> Timestamptz,

--- a/ft-sdk/src/auth/db.rs
+++ b/ft-sdk/src/auth/db.rs
@@ -1,0 +1,24 @@
+diesel::table! {
+    use diesel::sql_types::*;
+
+    fastn_user (id) {
+        id -> Int8,
+        name -> Nullable<Text>,
+        username -> Nullable<Text>,
+        data -> Jsonb,
+        created_at -> Timestamptz,
+        updated_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+
+    fastn_session (id) {
+        id -> Int8,
+        uid -> Nullable<Int8>,
+        data -> Jsonb,
+        updated_at -> Timestamptz,
+        created_at -> Timestamptz,
+    }
+}

--- a/ft-sdk/src/auth/mod.rs
+++ b/ft-sdk/src/auth/mod.rs
@@ -131,12 +131,7 @@ pub fn ud(
 
     let session_cookie = req.cookie(SESSION_KEY)?;
     let session_cookie = serde_json::from_str::<serde_json::Value>(session_cookie).ok()?;
-    let session_id = session_cookie
-        .as_object()?
-        .get("id")?
-        .as_number()?
-        .as_i64()?;
-
+    let session_id = session_cookie.as_object()?.get("id")?.as_str()?;
 
     let (user_id, user_data) = conn
         .transaction(|c| {

--- a/ft-sdk/src/auth/mod.rs
+++ b/ft-sdk/src/auth/mod.rs
@@ -1,5 +1,14 @@
+mod utils;
+
+mod db;
+
+#[cfg(feature = "auth-provider")]
+pub mod provider;
+
 #[derive(Clone)]
 pub struct UserId(pub i64);
+
+pub(crate) const SESSION_KEY: &str = "session";
 
 /// Any provider can provide any of this information about currently logged-in user,
 /// which is stored against the user in the database. The provider who drops in the
@@ -7,13 +16,8 @@ pub struct UserId(pub i64);
 #[derive(Debug, Clone, PartialEq)]
 pub enum UserData {
     VerifiedEmail(String),
-    Username(String),
-
     Name(String),
-    FirstName(String),
-    LastName(String),
     Email(String),
-    Age(u8),
     Phone(String),
     ProfilePicture(String),
     /// GitHub may use username as Identity, as user can understand their username, but have never
@@ -31,12 +35,8 @@ impl UserData {
     pub fn kind(&self) -> UserDataKind {
         match self {
             UserData::VerifiedEmail(_) => UserDataKind::VerifiedEmail,
-            UserData::Username(_) => UserDataKind::Username,
             UserData::Name(_) => UserDataKind::Name,
-            UserData::FirstName(_) => UserDataKind::FirstName,
-            UserData::LastName(_) => UserDataKind::LastName,
             UserData::Email(_) => UserDataKind::Email,
-            UserData::Age(_) => UserDataKind::Age,
             UserData::Phone(_) => UserDataKind::Phone,
             UserData::ProfilePicture(_) => UserDataKind::ProfilePicture,
             UserData::Identity(_) => UserDataKind::Identity,
@@ -106,21 +106,3 @@ pub fn session_providers() -> Vec<String> {
     todo!()
 }
 
-pub(crate) fn ud() -> Option<ft_sys::UserData> {
-    let user = ft_sys::env::var("DEBUG_LOGGED_IN".to_string());
-    match user {
-        Some(v) => {
-            let v: Vec<&str> = v.splitn(4, ' ').collect();
-            let ud = ft_sys::UserData {
-                id: v[0].parse().unwrap(),
-                username: v[1].to_string(),
-                name: v.get(3).map(|v| v.to_string()).unwrap_or_default(),
-                email: v.get(2).map(|v| v.to_string()).unwrap_or_default(),
-                verified_email: true,
-            };
-            ft_sdk::println!("Inside ud {ud:?}");
-            Some(ud)
-        }
-        None => None,
-    }
-}

--- a/ft-sdk/src/auth/provider.rs
+++ b/ft-sdk/src/auth/provider.rs
@@ -237,7 +237,8 @@ pub fn login(
         "identity": identity,
     }))?;
 
-    let session_cookie = ft_sdk::Cookie::new(ft_sdk::auth::SESSION_KEY, &session_str);
+    let mut session_cookie = ft_sdk::Cookie::new(ft_sdk::auth::SESSION_KEY, &session_str);
+    session_cookie.set_path("/");
 
     in_.add_cookie(session_cookie);
 

--- a/ft-sdk/src/auth/utils.rs
+++ b/ft-sdk/src/auth/utils.rs
@@ -1,0 +1,283 @@
+pub(crate) fn user_data_from_json(
+    data: serde_json::Value,
+) -> std::collections::HashMap<String, Vec<ft_sdk::auth::UserData>> {
+    assert!(data.is_object());
+
+    data.as_object()
+        .unwrap()
+        .into_iter()
+        .map(|(provider_id, p_data)| {
+            assert!(p_data.is_object());
+            let v = p_data.as_object().unwrap();
+
+            let data = if v.contains_key("data") {
+                assert!(v.get("data").unwrap().is_object());
+
+                let v = v.get("data").unwrap().as_object().unwrap();
+
+                let user_data = v
+                    .into_iter()
+                    .flat_map(|(k, v)| match k.as_str() {
+                        "verified_emails" => {
+                            let v = v.as_array().unwrap();
+
+                            v.iter()
+                                .map(|v| {
+                                    ft_sdk::auth::UserData::VerifiedEmail(
+                                        v.as_str().unwrap().to_string(),
+                                    )
+                                })
+                                .collect::<Vec<_>>()
+                        }
+                        "emails" => {
+                            let v = v.as_array().unwrap();
+
+                            v.iter()
+                                .map(|v| {
+                                    ft_sdk::auth::UserData::Email(v.as_str().unwrap().to_string())
+                                })
+                                .collect()
+                        }
+                        "identity" => {
+                            vec![ft_sdk::auth::UserData::Identity(
+                                v.as_str().unwrap().to_string(),
+                            )]
+                        }
+                        "name" => vec![ft_sdk::auth::UserData::Name(
+                            v.as_str().unwrap().to_string(),
+                        )],
+                        "phones" => {
+                            let v = v.as_array().unwrap();
+                            vec![ft_sdk::auth::UserData::Phone(
+                                v.iter().map(|v| v.as_str().unwrap().to_string()).collect(),
+                            )]
+                        }
+                        "profile_picture" => {
+                            vec![ft_sdk::auth::UserData::ProfilePicture(
+                                v.as_str().unwrap().to_string(),
+                            )]
+                        }
+                        _ => vec![ft_sdk::auth::UserData::Custom {
+                            key: k.to_string(),
+                            value: v.clone(),
+                        }],
+                    })
+                    .collect();
+
+                user_data
+            } else {
+                vec![]
+            };
+
+            (provider_id.to_string(), data)
+        })
+        .collect()
+}
+
+pub(crate) fn user_data_to_json(
+    data: std::collections::HashMap<String, Vec<ft_sdk::auth::UserData>>,
+) -> serde_json::Value {
+    use ft_sdk::auth::UserData;
+
+    let map = data
+        .into_iter()
+        .map(|(k, v)| {
+            let mut provider_data = serde_json::json!({
+                "data": {
+                    "emails": [],
+                    "verified_emails": [],
+                },
+            });
+
+            for ud in v {
+                match ud {
+                    UserData::VerifiedEmail(email) => provider_data
+                        .as_object_mut()
+                        .expect("value is object")
+                        .get_mut("data")
+                        .expect("data is prepopulated")
+                        .as_object_mut()
+                        .unwrap()
+                        .get_mut("verified_emails")
+                        .expect("verified_emails is prepopulated")
+                        .as_array_mut()
+                        .unwrap()
+                        .push(serde_json::Value::String(email)),
+
+                    UserData::Email(email) => provider_data
+                        .as_object_mut()
+                        .expect("value is object")
+                        .get_mut("data")
+                        .expect("data is prepopulated")
+                        .as_object_mut()
+                        .unwrap()
+                        .get_mut("emails")
+                        .expect("emails is prepopulated")
+                        .as_array_mut()
+                        .unwrap()
+                        .push(serde_json::Value::String(email)),
+
+                    UserData::Identity(identity) => {
+                        provider_data
+                            .as_object_mut()
+                            .expect("value is object")
+                            .get_mut("data")
+                            .expect("data is prepopulated")
+                            .as_object_mut()
+                            .unwrap()
+                            .insert("identity".to_string(), serde_json::Value::String(identity));
+                    }
+                    UserData::Name(name) => {
+                        provider_data
+                            .as_object_mut()
+                            .expect("value is object")
+                            .get_mut("data")
+                            .expect("data is prepopulated")
+                            .as_object_mut()
+                            .unwrap()
+                            .insert("name".to_string(), serde_json::Value::String(name));
+                    }
+                    UserData::Phone(phone) => {
+                        provider_data
+                            .as_object_mut()
+                            .expect("value is object")
+                            .get_mut("data")
+                            .expect("data is prepopulated")
+                            .as_object_mut()
+                            .unwrap()
+                            .insert("phone".to_string(), serde_json::Value::String(phone));
+                    }
+                    UserData::ProfilePicture(profile_picture) => {
+                        provider_data
+                            .as_object_mut()
+                            .expect("value is object")
+                            .get_mut("data")
+                            .expect("data is prepopulated")
+                            .as_object_mut()
+                            .unwrap()
+                            .insert(
+                                "profile_picture".to_string(),
+                                serde_json::Value::String(profile_picture),
+                            );
+                    }
+                    UserData::Custom { key, value } => {
+                        provider_data
+                            .as_object_mut()
+                            .expect("value is object")
+                            .get_mut("data")
+                            .expect("data is prepopulated")
+                            .as_object_mut()
+                            .unwrap()
+                            .insert(key, value);
+                    }
+                };
+            }
+
+            (k.to_string(), provider_data)
+        })
+        .collect();
+
+    serde_json::Value::Object(map)
+}
+
+#[cfg(test)]
+mod test {
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn user_data_to_json() {
+        use ft_sdk::auth::UserData;
+        let mut data = std::collections::HashMap::new();
+
+        data.insert(
+            "email".to_string(),
+            vec![
+                UserData::VerifiedEmail("test@test.com".into()),
+                UserData::Email("test@test.com".into()),
+                UserData::Name("John".into()),
+            ],
+        );
+
+        data.insert(
+            "gh-123".to_string(),
+            vec![ft_sdk::auth::UserData::VerifiedEmail(
+                "test@test.com".to_string(),
+            )],
+        );
+
+        let json = super::user_data_to_json(data);
+
+        let expected_json = serde_json::json!({
+            "email": {
+                "data": {
+                    "emails": [
+                        "test@test.com",
+                    ],
+                    "name": "John",
+                    "verified_emails": [
+                        "test@test.com",
+                    ],
+                },
+            },
+            "gh-123": {
+                "data": {
+                    "emails": [],
+                    "verified_emails": [
+                        "test@test.com",
+                    ],
+                },
+            },
+        });
+
+        assert_eq!(json, expected_json);
+    }
+
+    #[test]
+    fn user_data_from_json() {
+        use ft_sdk::auth::UserData;
+        use std::collections::HashMap;
+
+        let data = serde_json::json!({
+            "email": {
+                "data": {
+                    "emails": [
+                        "test@test.com",
+                        "spam@smth.com",
+                    ],
+                    "name": "John",
+                    "verified_emails": [
+                        "john@mail.com",
+                    ],
+                },
+            },
+            "gh-123": {
+                "data": {
+                    "verified_emails": [
+                        "john@gh.com",
+                    ],
+                },
+            },
+        });
+
+        let result = super::user_data_from_json(data);
+
+        let mut expected = HashMap::new();
+
+        expected.insert(
+            "email".to_string(),
+            vec![
+                UserData::Email("test@test.com".into()),
+                UserData::Email("spam@smth.com".into()),
+                UserData::Name("John".into()),
+                UserData::VerifiedEmail("john@mail.com".into()),
+            ],
+        );
+
+        expected.insert(
+            "gh-123".to_string(),
+            vec![UserData::VerifiedEmail("john@gh.com".into())],
+        );
+
+        assert_eq!(expected, result);
+    }
+}

--- a/ft-sdk/src/auth_provider.rs
+++ b/ft-sdk/src/auth_provider.rs
@@ -71,7 +71,13 @@ pub fn check_if_verified_email_exists(
     #[cfg(feature = "postgres")]
     ft_sdk::utils::dbg_query::<_, diesel::pg::Pg>(&query);
 
-    let count: i64 = query.get_result(conn)?;
+    let count: i64 = match query.get_result(conn) {
+        Ok(count) => count,
+        Err(e) => match e {
+            diesel::result::Error::NotFound => return Ok(false),
+            e => return Err(e),
+        },
+    };
 
     Ok(count > 0)
 }

--- a/ft-sdk/src/auth_provider.rs
+++ b/ft-sdk/src/auth_provider.rs
@@ -276,7 +276,7 @@ pub enum LoginError {
 ///
 /// Each provider can also drop in a token that can be used to call APIs that require
 /// a token. The token is stored against session, and is deleted when the user logs out.
-fn update_user(
+pub fn update_user(
     id: &ft_sdk::UserId,
     conn: &mut ft_sdk::Connection,
     provider_id: &str,

--- a/ft-sdk/src/auth_provider.rs
+++ b/ft-sdk/src/auth_provider.rs
@@ -51,6 +51,7 @@ pub fn check_if_verified_email_exists(
     use diesel::prelude::*;
     use diesel::sql_types::{Bool, Text};
 
+    // TODO: 'email' should come from `_provider`
     #[cfg(not(feature = "postgres"))]
     let filter = sql::<Bool>("data->'email'->'data'->'verified_emails' LIKE ")
         .bind::<Text, _>(format!("'%{}%'", email));
@@ -81,7 +82,6 @@ pub fn get_user_data_by_email(
     email: &str,
 ) -> Result<(ft_sdk::auth::UserId, Vec<ft_sdk::auth::UserData>), UserDataError> {
     use diesel::prelude::*;
-    use diesel::sql_types::Text;
 
     // TODO: don't load all the users, just load the user with the email
     // this is until we figure out why binds are not properly working

--- a/ft-sdk/src/cookie.rs
+++ b/ft-sdk/src/cookie.rs
@@ -76,7 +76,14 @@ impl CookieExt for ::http::Request<bytes::Bytes> {
             .and_then(|v| {
                 v.split(';')
                     .find(|v| v.trim_start().starts_with(name))
-                    .map(|v| v.trim_start().strip_prefix(name).unwrap().trim_start())
+                    .map(|v| {
+                        v.trim_start()
+                            .strip_prefix(name)
+                            .unwrap()
+                            .strip_prefix("=")
+                            .unwrap()
+                            .trim_start()
+                    })
             })
     }
 }

--- a/ft-sdk/src/email.rs
+++ b/ft-sdk/src/email.rs
@@ -22,7 +22,7 @@ pub fn send_email(
 ) -> Result<(), EmailError> {
     use diesel::prelude::*;
 
-    let now = chrono::Utc::now();
+    let now = ft_sdk::env::now();
     let (name, email) = to;
 
     let affected = diesel::insert_into(fastn_email_queue::table)

--- a/ft-sdk/src/in_.rs
+++ b/ft-sdk/src/in_.rs
@@ -14,10 +14,12 @@ pub struct In {
 
 impl In {
     pub fn from_request(req: http::Request<bytes::Bytes>) -> Result<Self, ft_sdk::Error> {
+        let mut conn = ft_sdk::default_connection()?;
+
         Ok(In {
-            req,
+            req: req.clone(),
             now: ft_sys::now(),
-            ud: ft_sdk::auth::ud(),
+            ud: ft_sdk::auth::ud(&req, &mut conn),
             set_cookies: Rc::new(RefCell::new(Vec::new())),
             form_errors: HashMap::new(),
         })

--- a/ft-sdk/src/lib.rs
+++ b/ft-sdk/src/lib.rs
@@ -8,8 +8,7 @@
 extern crate self as ft_sdk;
 
 pub mod auth;
-#[cfg(feature = "auth-provider")]
-pub mod auth_provider;
+
 mod rng;
 
 mod crypto;

--- a/ft-sdk/src/migration/sqlite.rs
+++ b/ft-sdk/src/migration/sqlite.rs
@@ -59,7 +59,7 @@ pub(super) const SESSION_TABLE: &str = r#"
 
 CREATE TABLE IF NOT EXISTS fastn_session
 (
-    id   INTEGER PRIMARY KEY,
+    id   TEXT PRIMARY KEY,
     uid  INTEGER NULL,
     data BLOB, -- this is the session data only
     created_at INTEGER NOT NULL,

--- a/ft-sdk/src/rng.rs
+++ b/ft-sdk/src/rng.rs
@@ -26,14 +26,10 @@ impl rand_core::RngCore for Rng {
     }
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {
-        if dest.len() < 8 {
-            fill_8_bytes(&mut dest[..8].try_into().unwrap());
-        } else {
-            let window = dest.windows(8);
-
-            for w in window {
-                fill_8_bytes(&mut w.try_into().unwrap());
-            }
+        for chunk in dest.chunks_mut(8) {
+            let mut w = [0u8; 8];
+            fill_8_bytes(&mut w);
+            chunk.copy_from_slice(&w);
         }
     }
 
@@ -46,8 +42,8 @@ impl rand_core::RngCore for Rng {
 fn fill_8_bytes(w: &mut [u8; 8]) {
     let val = ft_sdk::env::random().to_be_bytes();
 
-    for (i, byte) in w.iter_mut().enumerate() {
-        *byte = val[i];
+    for (i, byte) in val.iter().enumerate() {
+        w[i] = *byte;
     }
 }
 

--- a/ft-sys-shared/src/lib.rs
+++ b/ft-sys-shared/src/lib.rs
@@ -103,7 +103,7 @@ pub enum DecryptionError {
 #[serde(rename_all = "kebab-case")]
 pub struct UserData {
     pub id: i64,
-    pub username: String,
+    pub identity: String,
     pub name: String,
     pub email: String,
     pub verified_email: bool,

--- a/ft-sys/src/diesel_sqlite/types/jsonb.rs
+++ b/ft-sys/src/diesel_sqlite/types/jsonb.rs
@@ -13,7 +13,7 @@ impl sql_types::HasSqlType<sql_types::Jsonb> for Sqlite {
 
 impl ToSql<sql_types::Jsonb, Sqlite> for serde_json::Value {
     fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Sqlite>) -> serialize::Result {
-        let b = serde_sqlite_jsonb::to_vec(self)?;
+        let b = serde_json::to_vec(self)?;
         out.set_value(b);
         Ok(IsNull::No)
     }
@@ -22,7 +22,7 @@ impl ToSql<sql_types::Jsonb, Sqlite> for serde_json::Value {
 impl<'a> SqliteValue<'a> {
     pub(crate) fn jsonb(&self) -> diesel::deserialize::Result<serde_json::Value> {
         match self.raw_value {
-            ft_sys_shared::SqliteRawValue::Blob(i) => Ok(serde_sqlite_jsonb::from_slice(i)?),
+            ft_sys_shared::SqliteRawValue::Blob(i) => Ok(serde_json::from_slice(i)?),
             _ => Err(format!(
                 "Unexpected type, expected Blob, found: {:?}",
                 self.raw_value.kind()


### PR DESCRIPTION
- **use serde_json instead of serde_sqlite_jsonb**

    serde_sqlite_jsonb is not working as expected. Using serde_json until I
    figure out the why.

- **refactor: move auth.rs and auth_provider.rs into auth mod**

    - auth (and auth provider) related source files have been moved to the
      `ft-sdk/src/auth` folder.
    - `ft_sdk::auth_provider` is renamed to `ft_sdk::auth::provider`.

- **feat: impl ud()**

    `ft_sdk::ud()` can be used to get currently logged in user details.

- **fix: strip `=` from cookie value**

    Cookie `name=value;smth=smth_else;` after stripping cookie name we were
    left with `=value` if we called `req.cookie("name")`. This is fixed and you
    now get just `value`.

- **fix: rng**

    `ft_sdk::Rng::fill_bytes` was not filling the `dest` buffer which means we
    were not generating random numbers. This is fixed too.

- **use uuid for session id**

    `fastn_session(id)` is now a `Text` column that is filled with uuid
    generated using the `uuid` crate.

- **minor fixes**
    
    various other bugs have been fixed that were encountered while implementing
    the [email auth provider](https://github.com/fastn-community/auth/pull/1)
