### PR TITLE
Fix: Timestamptz deserialization

### DIFF
--- a/ft-sdk/src/migration/sqlite.rs
+++ b/ft-sdk/src/migration/sqlite.rs
@@ -55,19 +55,6 @@ CREATE TABLE IF NOT EXISTS fastn_user
 
 "#;
 
-// Todo: We need to use this table for migration from prod postgresql
-// This is the old table schema
-// CREATE TABLE IF NOT EXISTS fastn_user
-// (
-// "id"              integer PRIMARY KEY AUTOINCREMENT,
-// "username"        text NOT NULL UNIQUE,
-// "password"        text NOT NULL,
-// "email"           text NOT NULL,
-// "verified_email"  bool DEFAULT false NOT NULL,
-// "name"            text NOT NULL,
-// "created_at"      datetime NOT NULL,
-// "updated_at"      datetime NOT NULL
-// );
 
 pub(super) const SESSION_TABLE: &str = r#"
 

--- a/ft-sdk/src/migration/sqlite.rs
+++ b/ft-sdk/src/migration/sqlite.rs
@@ -55,6 +55,7 @@ CREATE TABLE IF NOT EXISTS fastn_user
 
 "#;
 
+// Todo: We need to use this table for migration from prod postgresql
 // This is the old table schema
 // CREATE TABLE IF NOT EXISTS fastn_user
 // (

--- a/ft-sdk/src/migration/sqlite.rs
+++ b/ft-sdk/src/migration/sqlite.rs
@@ -55,6 +55,19 @@ CREATE TABLE IF NOT EXISTS fastn_user
 
 "#;
 
+// This is the old table schema
+// CREATE TABLE IF NOT EXISTS fastn_user
+// (
+// "id"              integer PRIMARY KEY AUTOINCREMENT,
+// "username"        text NOT NULL UNIQUE,
+// "password"        text NOT NULL,
+// "email"           text NOT NULL,
+// "verified_email"  bool DEFAULT false NOT NULL,
+// "name"            text NOT NULL,
+// "created_at"      datetime NOT NULL,
+// "updated_at"      datetime NOT NULL
+// );
+
 pub(super) const SESSION_TABLE: &str = r#"
 
 CREATE TABLE IF NOT EXISTS fastn_session

--- a/ft-sys/src/diesel_sqlite/types/date_time.rs
+++ b/ft-sys/src/diesel_sqlite/types/date_time.rs
@@ -69,6 +69,15 @@ impl FromSql<diesel::sql_types::Timestamptz, Sqlite> for chrono::DateTime<chrono
                         chrono::Utc,
                     ));
                 }
+
+                // 2024-03-19 12:28:11.698379+05:30
+                if let Ok(v) = chrono::NaiveDateTime::parse_from_str(t, "%F %T%.6f%:z") {
+                    return Ok(chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(
+                        v,
+                        chrono::Utc,
+                    ));
+                }
+
                 Err(format!("Invalid datetime string: {:?}", t).into())
             }
             _ => Err(format!(


### PR DESCRIPTION
**Important:** This PR also contains the old `fastn_user` table... Since prod has this, we need it to do migration from prod PostgreSQL to sqlite.