### PR TITLE
Fix: cookie extraction logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## Unreleased
+
+### ft-sdk
+
+- Bug fix: `fastn-sid-1` cookie was found when we try `ft_sdk::Cookie<"fastn-sid">`.
+
 ## 11th June 2024
 
 ### ft-sdk: `0.1.9`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "ft-sdk"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "bytes",

--- a/ft-sdk/src/from_request/cookie.rs
+++ b/ft-sdk/src/from_request/cookie.rs
@@ -17,7 +17,7 @@ impl<const KEY: &'static str> ft_sdk::FromRequest for Cookie<KEY> {
                 .and_then(|v| v.to_str().ok())
                 .and_then(|v| {
                     v.split(';')
-                        .find(|v| v.trim_start().starts_with(KEY))
+                        .find(|v| v.trim_start().eq(KEY))
                         .map(|v| {
                             v.trim_start()
                                 .strip_prefix(KEY)


### PR DESCRIPTION
Bug fix: `fastn-sid-1` cookie was found when we try `ft_sdk::Cookie<"fastn-sid">`.