### PR TITLE
add functions to manage tracking information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `ft_sdk::tracker::{create_tracker, set_user_id}` functions for creating/updating tracker entries.
 - `ft_sdk::schema::fastn_tracker` diesel table definition.
 - `ft_sdk::utils::uuid_v8` function to generate uuids.
+- `ft_sdk::tracker::TRACKER_KEY` constant exposed for setting tracker cookie.
 - impl `Display` for `ft_sdk::PlainText`.
 
 ## 14th June 2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # ChangeLog
 
+## Unreleased
+
+- `ft_sdk::tracker::{create_tracker, set_user_id}` functions for creating/updating tracker entries.
+- `ft_sdk::schema::fastn_tracker` diesel table definition.
+- `ft_sdk::utils::uuid_v8` function to generate uuids.
+- impl `Display` for `ft_sdk::PlainText`.
+
 ## 14th June 2024
 
 ### ft-sdk: `0.1.12`

--- a/ft-sdk/src/auth/session.rs
+++ b/ft-sdk/src/auth/session.rs
@@ -32,6 +32,7 @@ pub fn set_user_id(
 }
 
 #[cfg(feature = "auth-provider")]
+/// Create a new session entry with the given user ID.
 pub fn create_with_user(
     conn: &mut ft_sdk::Connection,
     user_id: i64,
@@ -39,7 +40,7 @@ pub fn create_with_user(
     use diesel::prelude::*;
     use ft_sdk::auth::fastn_session;
 
-    let session_id = generate_new_session_id();
+    let session_id = ft_sdk::utils::uuid_v8();
 
     diesel::insert_into(fastn_session::table)
         .values((
@@ -54,11 +55,3 @@ pub fn create_with_user(
     Ok(ft_sdk::auth::SessionID(session_id))
 }
 
-#[cfg(feature = "auth-provider")]
-fn generate_new_session_id() -> String {
-    use rand_core::RngCore;
-
-    let mut rand_buf: [u8; 16] = Default::default();
-    ft_sdk::Rng::fill_bytes(&mut ft_sdk::Rng {}, &mut rand_buf);
-    uuid::Uuid::new_v8(rand_buf).to_string()
-}

--- a/ft-sdk/src/crypto.rs
+++ b/ft-sdk/src/crypto.rs
@@ -63,3 +63,9 @@ impl From<PlainText> for String {
         val.0
     }
 }
+
+impl std::fmt::Display for PlainText {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.0.as_str())
+    }
+}

--- a/ft-sdk/src/lib.rs
+++ b/ft-sdk/src/lib.rs
@@ -20,6 +20,8 @@ pub mod from_request;
 pub mod processor;
 mod rng;
 pub mod utils;
+pub mod schema;
+pub mod tracker;
 
 pub use anyhow::{anyhow, bail, ensure, Context, Error};
 pub use auth::UserId;

--- a/ft-sdk/src/schema.rs
+++ b/ft-sdk/src/schema.rs
@@ -1,0 +1,12 @@
+diesel::table! {
+    use diesel::sql_types::*;
+
+    fastn_tracker (id) {
+        id -> Text,
+        uid -> Nullable<Int8>,
+        updated_at -> Timestamptz,
+        created_at -> Timestamptz,
+    }
+}
+
+diesel::joinable!(fastn_tracker -> ft_sdk::auth::fastn_user (uid));

--- a/ft-sdk/src/tracker.rs
+++ b/ft-sdk/src/tracker.rs
@@ -1,3 +1,5 @@
+pub use ft_sys_shared::TRACKER_KEY;
+
 pub struct TrackerID(pub String);
 
 /// create a new tracker entry associated with `user_id` in the `fastn_tracker` table

--- a/ft-sdk/src/tracker.rs
+++ b/ft-sdk/src/tracker.rs
@@ -1,0 +1,41 @@
+pub struct TrackerID(pub String);
+
+/// create a new tracker entry associated with `user_id` in the `fastn_tracker` table
+/// `user_id` is optional, if not provided, the tracker will not be associated with any user. This
+/// is to indicate that the user has given cookie consent but has not logged in.
+pub fn create_tracker(
+    conn: &mut ft_sdk::Connection,
+    user_id: Option<i64>,
+) -> Result<TrackerID, diesel::result::Error> {
+    use diesel::prelude::*;
+    use ft_sdk::schema::fastn_tracker;
+
+    let session_id = ft_sdk::utils::uuid_v8();
+
+    diesel::insert_into(fastn_tracker::table)
+        .values((
+            fastn_tracker::id.eq(&session_id),
+            fastn_tracker::uid.eq(user_id),
+            fastn_tracker::created_at.eq(ft_sdk::env::now()),
+            fastn_tracker::updated_at.eq(ft_sdk::env::now()),
+        ))
+        .execute(conn)?;
+
+    Ok(TrackerID(session_id))
+}
+
+/// Update the tracker to be associated with the given user ID.
+pub fn set_user_id(
+    conn: &mut ft_sdk::Connection,
+    TrackerID(session_id): TrackerID,
+    user_id: i64,
+) -> Result<(), diesel::result::Error> {
+    use diesel::prelude::*;
+    use ft_sdk::schema::fastn_tracker;
+
+    diesel::update(fastn_tracker::table.filter(fastn_tracker::id.eq(session_id.as_str())))
+        .set(fastn_tracker::uid.eq(Some(user_id)))
+        .execute(conn)?;
+
+    Ok(())
+}

--- a/ft-sdk/src/utils.rs
+++ b/ft-sdk/src/utils.rs
@@ -31,3 +31,12 @@ pub fn dbg_query<T: diesel::query_builder::QueryFragment<B>, B: diesel::backend:
     #[cfg(feature = "debug")]
     ft_sdk::println!("{:?}", diesel::debug_query::<B, _>(_query));
 }
+
+/// Generate a new uuid v8 using the uuid crate
+pub fn uuid_v8() -> String {
+    use rand_core::RngCore;
+
+    let mut rand_buf: [u8; 16] = Default::default();
+    ft_sdk::Rng::fill_bytes(&mut ft_sdk::Rng {}, &mut rand_buf);
+    uuid::Uuid::new_v8(rand_buf).to_string()
+}

--- a/ft-sys-shared/src/lib.rs
+++ b/ft-sys-shared/src/lib.rs
@@ -7,6 +7,7 @@ mod sqlite;
 pub use sqlite::{SqliteRawValue, SqliteType};
 
 pub const SESSION_KEY: &str = "fastn-sid";
+pub const TRACKER_KEY: &str = "fastn_tid";
 
 /// Request acts as both a request and a response, and is only used for the
 /// communication between guest and host. It is not exposed via ft-sdk.


### PR DESCRIPTION
ft_sdk exposes some functions to create entries in the `fastn_tracker`
table. This is used for user activity tracking.