### PR TITLE
fix `ft_sdk::data::browser_redirect_with_cookie`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### ft-sdk
 
-- Added `ft_sdk::processor::browser_redirect` which is designed to handle cases where 
+- Added `ft_sdk::data::browser_redirect_with_cookie` which is designed to handle cases where 
   cookies need to be set, followed by a redirection of the browser.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-## 1st July 2024
-
 ### ft-sdk
 
 - Added `ft_sdk::processor::browser_redirect` which is designed to handle cases where 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 ## 1st July 2024
 
+### ft-sdk
+
 - Added `ft_sdk::processor::browser_redirect` which is designed to handle cases where 
   cookies need to be set, followed by a redirection of the browser.
 
-### ft-sdk
 
 
 ## 28th June 2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # ChangeLog
 
+## Unreleased
+
+## 1st July 2024
+
+- Added `ft_sdk::processor::browser_redirect` which is designed to handle cases where 
+  cookies need to be set, followed by a redirection of the browser.
+
+### ft-sdk
+
+
 ## 28th June 2024
 
 ### ft-sdk: `0.1.14`

--- a/examples/004-ft-stripe/Cargo.lock
+++ b/examples/004-ft-stripe/Cargo.lock
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "ft-sdk"
-version = "0.1.12"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "bytes",
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "ft-sys"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bytes",
  "chrono",
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "ft-sys-shared"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bytes",
  "chrono",

--- a/ft-sdk/src/data.rs
+++ b/ft-sdk/src/data.rs
@@ -4,6 +4,7 @@ pub type Result = std::result::Result<ft_sdk::chr::CHR<Output>, ft_sdk::Error>;
 pub enum Output {
     Json(serde_json::Value),
     Binary(Binary),
+    /// This variant is intended for setting cookies and then redirecting the browser.
     Redirect(String, http::HeaderValue),
 }
 
@@ -47,8 +48,11 @@ impl From<ft_sdk::chr::CHR<Output>>
             Output::Binary(binary) => binary_response(binary),
             Output::Redirect(url, cookie) => Ok(http::Response::builder()
                 .status(200)
-                .header("Set-Cookie", cookie)
-                .body(format!("<meta http-equiv='refresh' content='0; url={url}' />").into())?),
+                .header(http::header::SET_COOKIE, cookie)
+                .header(http::header::CONTENT_TYPE, "text/html; charset=utf-8")
+                .body(
+                    format!("<meta http-equiv='refresh' content='0; url={url}' /><link rel='canonical' href='{url}'>").into()
+                )?),
         }?;
         ft_sdk::chr::chr(cookies, headers, response)
     }

--- a/ft-sdk/src/lib.rs
+++ b/ft-sdk/src/lib.rs
@@ -19,11 +19,10 @@ pub mod form;
 pub mod from_request;
 pub mod processor;
 mod rng;
-pub mod utils;
 pub mod schema;
 pub mod session;
+pub mod utils;
 
-pub use session::{SessionID, SessionData};
 pub use anyhow::{anyhow, bail, ensure, Context, Error};
 pub use auth::UserId;
 pub use crypto::{DecryptionError, EncryptedString, PlainText};
@@ -39,6 +38,7 @@ pub use ft_sys::PgConnection;
 pub use ft_sys::SqliteConnection;
 pub use ft_sys::{env, http, println, ConnectionError, UserData};
 pub use rng::Rng;
+pub use session::{SessionData, SessionID};
 
 pub type FrontendData = std::collections::HashMap<String, serde_json::Value>;
 pub type FormError = std::collections::HashMap<String, String>;

--- a/ft-sdk/src/processor.rs
+++ b/ft-sdk/src/processor.rs
@@ -2,12 +2,8 @@ pub type Result = std::result::Result<ft_sdk::chr::CHR<Output>, ft_sdk::Error>;
 
 #[derive(Debug)]
 pub enum Output {
-    /// This variant is used for redirection.
     Redirect(u16, String),
-    /// This variant is used for returning JSON data.
     Json(serde_json::Value),
-    /// This variant is intended for setting cookies and then redirecting the browser.
-    BrowserRedirect(String),
 }
 
 impl Output {
@@ -18,7 +14,6 @@ impl Output {
         match self {
             Output::Redirect(code, url) => Output::Redirect(code, url),
             Output::Json(j) => Output::Json(f(j)),
-            Output::BrowserRedirect(url) => Output::BrowserRedirect(url),
         }
     }
 }
@@ -39,16 +34,6 @@ impl From<ft_sdk::chr::CHR<Output>>
                 .header("Location", url)
                 .body("".into())?),
             Output::Json(j) => ft_sdk::json(j),
-            Output::BrowserRedirect(url) => Ok(http::Response::builder()
-                // This status code indicates that the request has been accepted for processing,
-                // but the processing is not yet complete. It's a way to acknowledge that the
-                // request has been received and that further action (the redirection) will be
-                // taken by the client.
-                .status(202)
-                .header("content-type", "text/html; charset=utf-8")
-                .body(
-                    format!("<meta http-equiv='refresh' content='0; url={url}' /><link rel='canonical' href='{url}'>").into()
-                )?)
         }?;
         ft_sdk::chr::chr(cookies, headers, response)
     }
@@ -58,12 +43,6 @@ pub fn json<T: serde::Serialize>(j: T) -> Result {
     Ok(ft_sdk::chr::CHR::new(Output::Json(serde_json::to_value(
         j,
     )?)))
-}
-
-pub fn browser_redirect<S: AsRef<str>>(url: S) -> Result {
-    Ok(ft_sdk::chr::CHR::new(Output::BrowserRedirect(
-        url.as_ref().to_string(),
-    )))
 }
 pub fn permanent_redirect<S: AsRef<str>>(url: S) -> Result {
     Ok(ft_sdk::chr::CHR::new(Output::Redirect(

--- a/ft-sdk/src/processor.rs
+++ b/ft-sdk/src/processor.rs
@@ -2,8 +2,12 @@ pub type Result = std::result::Result<ft_sdk::chr::CHR<Output>, ft_sdk::Error>;
 
 #[derive(Debug)]
 pub enum Output {
+    /// This variant is used for redirection.
     Redirect(u16, String),
+    /// This variant is used for returning JSON data.
     Json(serde_json::Value),
+    /// This variant is intended for setting cookies and then redirecting the browser.
+    BrowserRedirect(String),
 }
 
 impl Output {
@@ -14,6 +18,7 @@ impl Output {
         match self {
             Output::Redirect(code, url) => Output::Redirect(code, url),
             Output::Json(j) => Output::Json(f(j)),
+            Output::BrowserRedirect(url) => Output::BrowserRedirect(url),
         }
     }
 }
@@ -34,6 +39,14 @@ impl From<ft_sdk::chr::CHR<Output>>
                 .header("Location", url)
                 .body("".into())?),
             Output::Json(j) => ft_sdk::json(j),
+            Output::BrowserRedirect(url) => Ok(http::Response::builder()
+                // This status code indicates that the request has been accepted for processing,
+                // but the processing is not yet complete. It's a way to acknowledge that the
+                // request has been received and that further action (the redirection) will be
+                // taken by the client.
+                .status(202)
+                .header("content-type", "text/html; charset=utf-8")
+                .body(format!("<meta http-equiv='refresh' content='0; url={url}' />").into())?)
         }?;
         ft_sdk::chr::chr(cookies, headers, response)
     }
@@ -45,6 +58,11 @@ pub fn json<T: serde::Serialize>(j: T) -> Result {
     )?)))
 }
 
+pub fn browser_redirect<S: AsRef<str>>(url: S) -> Result {
+    Ok(ft_sdk::chr::CHR::new(Output::BrowserRedirect(
+        url.as_ref().to_string(),
+    )))
+}
 pub fn permanent_redirect<S: AsRef<str>>(url: S) -> Result {
     Ok(ft_sdk::chr::CHR::new(Output::Redirect(
         308,

--- a/ft-sdk/src/processor.rs
+++ b/ft-sdk/src/processor.rs
@@ -46,7 +46,9 @@ impl From<ft_sdk::chr::CHR<Output>>
                 // taken by the client.
                 .status(202)
                 .header("content-type", "text/html; charset=utf-8")
-                .body(format!("<meta http-equiv='refresh' content='0; url={url}' />").into())?)
+                .body(
+                    format!("<meta http-equiv='refresh' content='0; url={url}' /><link rel='canonical' href='{url}'>").into()
+                )?)
         }?;
         ft_sdk::chr::chr(cookies, headers, response)
     }


### PR DESCRIPTION
This PR introduces a new `ft_sdk::processor::Output` variant called `BrowserRedirect`. The `BrowserRedirect` variant is designed to handle cases where cookies need to be set, followed by a redirection of the browser.